### PR TITLE
Fix hardcoding for bayleef and eviolite 

### DIFF
--- a/scripts/explore.js
+++ b/scripts/explore.js
@@ -3594,7 +3594,7 @@ function exploreCombatWild() {
         if (team[exploreActiveMember].item == item.colburBerry.id && move[nextMoveWild].type == 'dark' && superEffective) {totalPower /= (item.colburBerry.power() /100) +1}
         if (team[exploreActiveMember].item == item.babiriBerry.id && move[nextMoveWild].type == 'steel' && superEffective) {totalPower /= (item.babiriBerry.power() /100) +1}
 
-        if (team[exploreActiveMember].item == item.eviolite.id && pkmn[team[exploreActiveMember].pkmn.id].evolve !== undefined && ( pkmn[team[exploreActiveMember].pkmn.id].evolve()[1].pkmn.id.slice(0, 4) !== "mega" || team[exploreActiveMember].pkmn.id == pkmn.bayleef.id) ) 
+        if (team[exploreActiveMember].item == item.eviolite.id && pkmn[team[exploreActiveMember].pkmn.id].evolve !== undefined && (!/^mega[A-Z]$/.test(pkmn[team[exploreActiveMember].pkmn.id].evolve()[1].pkmn.id.slice(0, 5))) )
         {totalPower /= item.eviolite.power();}
 
         if (team[exploreActiveMember].item == item.mentalHerb.id) {totalPower /= (item.mentalHerb.power() /100) +1}


### PR DESCRIPTION
by grabbing an extra character from the id and checking if it is capital letter.