### PR TITLE
autoteam: fix weight loss + feature item lock (optional)

### DIFF
--- a/scripts/PR/autoTeamBuilding.js
+++ b/scripts/PR/autoTeamBuilding.js
@@ -10,11 +10,23 @@
 
 
 
-//PR-EDIT------------------------------------
 function openAutoTeam(){
     document.getElementById("tooltipTop").style.display = "none"
     document.getElementById("tooltipTitle").innerHTML = "Team Auto-Build"
 
+    const currentTeam = saved.previewTeams[saved.currentPreviewTeam]
+    let itemCheckboxesHTML = ''
+    for (let i = 1; i <= 6; i++) {
+        const slotKey = `slot${i}`
+        const itemName = currentTeam[slotKey].item || 'No item'
+        itemCheckboxesHTML += `
+              <label style="display:flex; align-items:center; gap:.5rem; font-size:0.9rem;">
+                <input id="settings-auto-team-lock-item-${i}" type="checkbox" />
+                Lock ${itemName} (Slot ${i})
+              </label>`
+    }
+
+    //PR-EDIT------------------------------------
 
     document.getElementById("tooltipMid").innerHTML = `Select your preference for the team (Your current team will be replaced by it)`
     document.getElementById("tooltipBottom").innerHTML = `
@@ -34,10 +46,7 @@ function openAutoTeam(){
                 value="50"
               />
 
-              <label style="display:flex; align-items:center; gap:.5rem; font-size:0.9rem;">
-                <input id="settings-auto-team-lock-items" type="checkbox" />
-                Lock items (preserve items during auto-build)
-              </label>
+              ${itemCheckboxesHTML}
     </div>
 
     <div onClick = '
@@ -71,24 +80,6 @@ function setAutoTeamBiasFromPercent(pct){
   const label = document.getElementById("settings-auto-team-label");
   if (label) label.textContent = `Offense ${Math.round(off*100)}% / Defense ${Math.round(def*100)}%`;
 }
-
-
-/* - not needed PR-EDIT
-function initAutoTeamBiasSlider(){
-  const slider = document.getElementById("settings-auto-team-bias");
-  if (!slider) return
-
-  const currentOffPct = Math.round((window.autoTeamWeights?.offense ?? 0.6) * 100);
-  slider.value = String(currentOffPct);
-  setAutoTeamBiasFromPercent(currentOffPct);
-  console.log(currentOffPct)
-
-  slider.addEventListener("input", (e) => {
-    setAutoTeamBiasFromPercent(Number(e.target.value))
-  })
-}*/
-
-
 
 let autoTeamWeights = { offense: 0.6, defense: 0.4 } // scoring weights, bias slightly toward offense
 window.autoTeamWeights = autoTeamWeights;
@@ -325,14 +316,14 @@ function autoBuildTeam() {
   for (let i = 1; i <= 6; i++) {
     const slotKey = `slot${i}`
     const newPkmn = optimizedTeam[i - 1]
-    const lockItems = document.getElementById("settings-auto-team-lock-items")?.checked === true
+    const lockThisItem = document.getElementById(`settings-auto-team-lock-item-${i}`)?.checked === true
 
     if (newPkmn) {
       currentTeam[slotKey].pkmn = newPkmn
-      if (!lockItems) currentTeam[slotKey].item = undefined
+      if (!lockThisItem) currentTeam[slotKey].item = undefined
     } else {
       currentTeam[slotKey].pkmn = undefined
-      if (!lockItems) currentTeam[slotKey].item = undefined
+      if (!lockThisItem) currentTeam[slotKey].item = undefined
     }
   }
 


### PR DESCRIPTION
Added a lock item option in the popup in order to prevent reset with selectable slot to lock

Fixed a bug related to weight loss during auto build
steps to reproduce: 
1) use autobuild and build a full offense team
2) use auto build again but let it balanced at the middle
3) team won't update

Now it should be fixed 

(will need to be loaded in index.html of course)

@play-pokechill please feel free to change the ui element ˆˆ