### PR TITLE
feat: expanded search results to include evolution family

### DIFF
--- a/scripts/explore.js
+++ b/scripts/explore.js
@@ -3994,6 +3994,8 @@ document.getElementById("pokedex-search").addEventListener("keydown", e => {
       results = items.map(item => ({ item }))
     }
     
+    results = expandSearchWithEvolutionFamily(results)
+
     searchedPkmn = results
     updatePokedex()
   }
@@ -4003,6 +4005,25 @@ document.getElementById("pokedex-search").addEventListener("keydown", e => {
 
 let fusePkmn;
 let searchedPkmn = []
+
+function expandSearchWithEvolutionFamily(results) {
+    if (!Array.isArray(results) || results.length === 0) return results
+    if (!fusePkmn || !fusePkmn.getIndex) return results
+
+    const allowed = new Set(fusePkmn.getIndex().docs)
+    const expanded = new Set()
+
+    results.forEach(r => expanded.add(r.item))
+
+    results.forEach(r => {
+        const family = getEvolutionFamily(r.item)
+        family.forEach(member => {
+            if (allowed.has(member) && member?.caught > 0) expanded.add(member)
+        })
+    })
+
+    return Array.from(expanded).map(item => ({ item }))
+}
 
 
 function updatePokedex(){


### PR DESCRIPTION
**Summary**
This PR enhances the Pokédex search experience by expanding matched results to include the full evolution family of each Pokémon returned by the query.

**Motivation**
Currently, searching for a single stage of a Pokémon only returns that specific entry. In practice, users often expect to see related evolution stages as well (e.g., searching for a base form and discovering its evolutions).

**Changes**

- Introduces expandSearchWithEvolutionFamily() to post-process search results.
- Applies expansion after exclude-term filtering, preserving existing behavior.
- Deduplicates results before returning them.

**Testing**

- Search for a Pokémon with a known evolution line (e.g., a starter).
- Verify that other stages in the same evolution family appear in the results.
- Add an exclusion term and confirm excluded Pokémon do not appear, even if they belong to the same family.

**Notes**
If preferred I could make a filter option to better match expected UX.