### PR TITLE
Float numbers display issue in item description FIX

### DIFF
--- a/scripts/itemDictionary.js
+++ b/scripts/itemDictionary.js
@@ -186,7 +186,7 @@ item.ejectButton = {
 item.quickClaw = {
     type: "held",
     info: function() {return `When held: Moves that attack faster than usual are executed x${this.power()} faster`},
-    power : function() { return (100+(10*returnItemLevel(this.id)))/100}
+    power : function() { return (100+(15*returnItemLevel(this.id)))/100}
 }
 
 item.loadedDice = {
@@ -198,7 +198,7 @@ item.loadedDice = {
 item.metronome = {
     type: "held",
     info: function() {return `When held: Moves that get more powerful the more stacks they have deal x${this.power()} more damage`},
-    power : function() { return (110+(10*returnItemLevel(this.id)))/100}
+    power : function() { return (110+(15*returnItemLevel(this.id)))/100}
 }
 
 item.powerHerb = {
@@ -210,13 +210,13 @@ item.powerHerb = {
 item.luckyPunch = {
     type: "held",
     info: function() {return `When held: Moves affected by Iron Fist deal x${this.power()} more damage, and their secondary effects are twice as likely to happen`},
-    power : function() { return (100+(10*returnItemLevel(this.id)))/100}
+    power : function() { return (100+(15*returnItemLevel(this.id)))/100}
 }
 
 item.laggingTail = {
     type: "held",
     info: function() {return `When held: Moves that attack slower than usual deal x${this.power()} more damage`},
-    power : function() { return (110+(10*returnItemLevel(this.id)))/100}
+    power : function() { return (110+(15*returnItemLevel(this.id)))/100}
 }
 
 item.weaknessPolicy = {


### PR DESCRIPTION
An issue has been reported on the official discord server (message id: 1465973425733501052) showing the item description of a lvl 2 lagging tail, which mentions a multiplicative bonus of "1.4000000000000001".

To address this issue I replaced floating point numbers in the item dictionary with integer numbers (representing percentages so that it is still easy to read and edit) that are then divided by a hundred, so that it prevents the accumulation of rounding errors which was causing the issue (c.f. IEEE754)