### PR TITLE
Fix: Settings hideGotPkmn

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -881,7 +881,7 @@ function updateSettings(alt){
 
   document.getElementById("settings-theme").value = saved.theme
 
-  if (saved.hideGotPkmn) {document.getElementById("settings-hide-got").value = "true"} else document.getElementById("settings-hide-got").value = "false"
+  if (saved.hideGotPkmn == "true") {document.getElementById("settings-hide-got").value = "true"} else document.getElementById("settings-hide-got").value = "false"
   if (saved.alternateWildRotation == "true") {document.getElementById("settings-alternate-rotation").value = "true"} else document.getElementById("settings-alternate-rotation").value = "false"
 
 


### PR DESCRIPTION
Fix the HideGotPkmn as it assume value was a boolean instead of the true/false strings as alternateWildRotation is